### PR TITLE
chore: migrate <<HASH>> placeholder to <<VERSION>>

### DIFF
--- a/DeviceTester.kicad_pcb
+++ b/DeviceTester.kicad_pcb
@@ -9,7 +9,7 @@
 	(paper "A4")
 	(title_block
 		(title "Device Tester")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 		(comment 1 "JLC04161H-7628")
 	)
@@ -7793,7 +7793,7 @@
 			(justify left bottom)
 		)
 	)
-	(gr_text "<<HASH>>"
+	(gr_text "<<VERSION>>"
 		(at 104.969 109.634 0)
 		(layer "F.SilkS")
 		(uuid "46e35f71-37e3-4fa0-adfc-a652d885bf1f")

--- a/DeviceTester.kicad_sch
+++ b/DeviceTester.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "Device Tester")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/bus_tester_connector.kicad_sch
+++ b/bus_tester_connector.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "Device Tester Connector")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/device_tester_connector.kicad_sch
+++ b/device_tester_connector.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "Device Tester Connector")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols


### PR DESCRIPTION
## Summary

- Mechanisches sed-Replace `<<HASH>>` → `<<VERSION>>` in allen `.kicad_sch` und `.kicad_pcb`-Files.
- Keine elektrische oder Layout-Änderung — nur der Platzhalter-Name im Titelblock-Silkscreen.

## Phase 3 von 7 — Release-Konzept

- **Phase 1**: VERSIONING.md auf OE5XRX.github.io ([PR #3](https://github.com/OE5XRX/OE5XRX.github.io/pull/3))
- **Phase 2**: HW-Module-CI Workflow-Umstellung ([PR #4](https://github.com/OE5XRX/HW-Module-CI/pull/4)) — **muss zuerst gemergt sein**
- **Phase 3**: Diese PR (5 parallel — 1 pro Modul-Repo)

### Merge-Reihenfolge

1. HW-Module-CI#4 mergen
2. Direkt danach diese PR + die 4 Schwestern in den anderen Modul-Repos

Während des Zeitfensters zeigt das Titelblock kurzzeitig literal `<<HASH>>` (CI sucht nach `<<VERSION>>`, findet nichts, kein Substitut). Beim ersten `push:main` nach den Merges ist alles wieder konsistent.

## Test plan

- [ ] KiCad-Check CI grün (ERC + DRC unverändert)
- [ ] Nach Merge: einmal `workflow_dispatch` von „Create Debug Docs" und sichten dass im PDF-Schaltplan das Titelblock z.B. `BETA-<commit>` zeigt
- [ ] Erst danach `v1.0`-Release triggern (Phase 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)